### PR TITLE
Minor fixes to GitHub workflows

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -2,7 +2,7 @@
 
 name: Lint
 
-on: [push]
+on: [ push, pull_request ]
 
 jobs:
   lint:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -10,7 +10,7 @@ on:
     branches: [ '**' ]
 
 jobs:
-  pytest:
+  project-validation:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
When copying the new workflows to the project-repos that already use the nomenclature package, I noticed two minor issues:
- wrong workflow name
- executing the linter only on push means that the check is executed on a fork, but not shown when doing a PR across forks